### PR TITLE
Adds ECR Marketplace Action

### DIFF
--- a/.github/workflows/build-marketplace-ecr-images.yaml
+++ b/.github/workflows/build-marketplace-ecr-images.yaml
@@ -30,9 +30,6 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_GITHUB_RUNNER_ACCESS_KEY }}
         aws-secret-access-key: ${{ secrets.AWS_GITHUB_RUNNER_SECRET_KEY }}
         aws-region: us-east-1
-    
-    - name: get caller identity
-      run: aws sts get-caller-identity
 
     - name: Login to Amazon ECR
       id: login-ecr

--- a/.github/workflows/build-marketplace-ecr-images.yaml
+++ b/.github/workflows/build-marketplace-ecr-images.yaml
@@ -1,0 +1,30 @@
+name: build-marketplace-ecr-images
+
+on:
+    workflow_call:
+
+permissions:
+    contents: write # needed to write releases
+
+jobs:
+  build-marketplace-ecr-images:
+    name: Test Role Auth
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Configure AWS credentials from Test account
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::392256805076:role/manage-marketplace-ecr
+        role-session-name: github-action-build-images
+        aws-access-key-id: ${{ secrets.AWS_PLATFORM_ENGINEERING_ORCHESTRATION_GITHUB_ACTIONS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_PLATFORM_ENGINEERING_ORCHESTRATION_GITHUB_ACTIONS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+    - name: get caller identity
+      run: |
+        aws sts get-caller-identity

--- a/.github/workflows/build-marketplace-ecr-images.yaml
+++ b/.github/workflows/build-marketplace-ecr-images.yaml
@@ -8,9 +8,6 @@ on:
       AWS_GITHUB_RUNNER_SECRET_KEY:
         required: true
 
-permissions:
-    contents: write # needed to write releases
-
 jobs:
   build-marketplace-ecr-images:
     name: Test Role Auth

--- a/.github/workflows/build-marketplace-ecr-images.yaml
+++ b/.github/workflows/build-marketplace-ecr-images.yaml
@@ -1,7 +1,7 @@
 name: build-marketplace-ecr-images
 
 on:
-    workflow_call:
+  workflow_call:
 
 permissions:
     contents: write # needed to write releases
@@ -10,10 +10,6 @@ jobs:
   build-marketplace-ecr-images:
     name: Test Role Auth
     runs-on: ubuntu-latest
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
-      contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/build-marketplace-ecr-images.yaml
+++ b/.github/workflows/build-marketplace-ecr-images.yaml
@@ -2,6 +2,11 @@ name: build-marketplace-ecr-images
 
 on:
   workflow_call:
+    secrets:
+      AWS_PLATFORM_ENGINEERING_ORCHESTRATION_GITHUB_ACTIONS_ACCESS_KEY_ID:
+        required: true
+      AWS_PLATFORM_ENGINEERING_ORCHESTRATION_GITHUB_ACTIONS_SECRET_ACCESS_KEY:
+        required: true
 
 permissions:
     contents: write # needed to write releases

--- a/.github/workflows/build-marketplace-ecr-images.yaml
+++ b/.github/workflows/build-marketplace-ecr-images.yaml
@@ -40,6 +40,8 @@ jobs:
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2
+      with:
+        registries: "709825985650"
 
     - name: Build ECR Image
       run: make build_image

--- a/.github/workflows/build-marketplace-ecr-images.yaml
+++ b/.github/workflows/build-marketplace-ecr-images.yaml
@@ -3,9 +3,9 @@ name: build-marketplace-ecr-images
 on:
   workflow_call:
     secrets:
-      AWS_PLATFORM_ENGINEERING_ORCHESTRATION_GITHUB_ACTIONS_ACCESS_KEY_ID:
+      AWS_GITHUB_RUNNER_ACCESS_KEY:
         required: true
-      AWS_PLATFORM_ENGINEERING_ORCHESTRATION_GITHUB_ACTIONS_SECRET_ACCESS_KEY:
+      AWS_GITHUB_RUNNER_SECRET_KEY:
         required: true
 
 permissions:
@@ -21,15 +21,15 @@ jobs:
     - name: Echo
       run: echo access $AWS_ACCESS_KEY_ID secret $AWS_SECRET_KEY
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PLATFORM_ENGINEERING_ORCHESTRATION_GITHUB_ACTIONS_ACCESS_KEY_ID }}
-        AWS_SECRET_KEY: ${{ secrets.AWS_PLATFORM_ENGINEERING_ORCHESTRATION_GITHUB_ACTIONS_SECRET_ACCESS_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GITHUB_RUNNER_ACCESS_KEY }}
+        AWS_SECRET_KEY: ${{ secrets.AWS_GITHUB_RUNNER_SECRET_KEY }}
     - name: Configure AWS credentials from Test account
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::392256805076:role/manage-marketplace-ecr
         role-session-name: github-action-build-images
-        aws-access-key-id: ${{ secrets.AWS_PLATFORM_ENGINEERING_ORCHESTRATION_GITHUB_ACTIONS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_PLATFORM_ENGINEERING_ORCHESTRATION_GITHUB_ACTIONS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_GITHUB_RUNNER_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_GITHUB_RUNNER_SECRET_KEY }}
         aws-region: us-east-1
     - name: get caller identity
       run: |

--- a/.github/workflows/build-marketplace-ecr-images.yaml
+++ b/.github/workflows/build-marketplace-ecr-images.yaml
@@ -12,6 +12,7 @@ jobs:
   build-marketplace-ecr-images:
     name: Test Role Auth
     runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'renovate') == false
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/build-marketplace-ecr-images.yaml
+++ b/.github/workflows/build-marketplace-ecr-images.yaml
@@ -18,12 +18,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Echo
-      run: echo access $AWS_ACCESS_KEY_ID secret $AWS_SECRET_KEY
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GITHUB_RUNNER_ACCESS_KEY }}
-        AWS_SECRET_KEY: ${{ secrets.AWS_GITHUB_RUNNER_SECRET_KEY }}
-    - name: Configure AWS credentials from Test account
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Assume Marketplace Integration Role
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::392256805076:role/manage-marketplace-ecr
@@ -31,6 +33,19 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_GITHUB_RUNNER_ACCESS_KEY }}
         aws-secret-access-key: ${{ secrets.AWS_GITHUB_RUNNER_SECRET_KEY }}
         aws-region: us-east-1
+    
     - name: get caller identity
-      run: |
-        aws sts get-caller-identity
+      run: aws sts get-caller-identity
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - name: Build ECR Image
+      run: make build_image
+      env:
+        GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        GITHUB_REF: ${{ github.ref }}
+        REGISTRY: 709825985650.dkr.ecr.us-east-1.amazonaws.com/ksoc-labs
+        BRANCH: ${{ github.base_ref }}
+        COMMIT: ${{ github.sha }}

--- a/.github/workflows/build-marketplace-ecr-images.yaml
+++ b/.github/workflows/build-marketplace-ecr-images.yaml
@@ -13,6 +13,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Echo
+      run: echo access $AWS_ACCESS_KEY_ID secret $AWS_SECRET_KEY
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PLATFORM_ENGINEERING_ORCHESTRATION_GITHUB_ACTIONS_ACCESS_KEY_ID }}
+        AWS_SECRET_KEY: ${{ secrets.AWS_PLATFORM_ENGINEERING_ORCHESTRATION_GITHUB_ACTIONS_SECRET_ACCESS_KEY }}
     - name: Configure AWS credentials from Test account
       uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/build-marketplace-ecr-images.yaml
+++ b/.github/workflows/build-marketplace-ecr-images.yaml
@@ -26,23 +26,23 @@ jobs:
     - name: Assume Marketplace Integration Role
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::392256805076:role/manage-marketplace-ecr
+        role-to-assume: ${{ vars.AWS_MARKETPLACE_ROLE }}
         role-session-name: github-action-build-images
         aws-access-key-id: ${{ secrets.AWS_GITHUB_RUNNER_ACCESS_KEY }}
         aws-secret-access-key: ${{ secrets.AWS_GITHUB_RUNNER_SECRET_KEY }}
-        aws-region: us-east-1
+        aws-region: ${{ vars.AWS_MARKETPLACE_REGION }}
 
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2
       with:
-        registries: "709825985650"
+        registries: ${{ vars.AWS_MARKETPLACE_REGISTRY_ACCOUNT_ID }}
 
     - name: Build ECR Image
       run: make build_image
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         GITHUB_REF: ${{ github.ref }}
-        REGISTRY: 709825985650.dkr.ecr.us-east-1.amazonaws.com/ksoc-labs
+        REGISTRY: ${{ vars.AWS_MARKETPLACE_REGISTRY }}
         BRANCH: ${{ github.base_ref }}
         COMMIT: ${{ github.sha }}


### PR DESCRIPTION
Towards ENG-1213


Adds a new Github Action to push images to our ECR Registry for our AWS Marketplace Offering.

This is an example of what was run here within ksoc-guard here: https://github.com/ksoc-private/plugin-ksoc-guard/pull/135

```yaml
name: build-marketplace-images

on:
  pull_request:

permissions:
  contents: write

jobs:
  build_marketplace_images:
    uses: ksoc-private/go-github-actions/.github/workflows/build-marketplace-ecr-images.yaml@Add_ECS_Marketplace_Action
    secrets: inherit
```

This is the resulting object from `aws ecr describe-images --registry-id 709825985650 --repository-name ksoc-labs/ksoc-guard --region us-east-1`

```json
        {
            "registryId": "709825985650",
            "repositoryName": "ksoc-labs/ksoc-guard",
            "imageDigest": "sha256:c1a95c2b87dfc1baaa609d1b28a4d6d581b10c169e3cab0dd05687a93293ff8d",
            "imageTags": [
                "baa872e"
            ],
            "imageSizeInBytes": 33866423,
            "imagePushedAt": "2024-01-03T18:14:20+08:00",
            "imageManifestMediaType": "application/vnd.oci.image.index.v1+json"
        },
```