### PR TITLE
Updates naming of the ECR Image Building Job

### DIFF
--- a/.github/workflows/build-marketplace-ecr-images.yaml
+++ b/.github/workflows/build-marketplace-ecr-images.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-marketplace-ecr-images:
-    name: Test Role Auth
+    name: Build AWS Marketplace ECR Image
     runs-on: ubuntu-latest
     if: startsWith(github.head_ref, 'renovate') == false
     steps:


### PR DESCRIPTION
Towards ENG-1213

Updates the naming of the image building job to be `Build AWS Marketplace ECR Image`