### PR TITLE
Add ECR Public Image Action

### DIFF
--- a/.github/workflows/build-public-ecr-images.yml
+++ b/.github/workflows/build-public-ecr-images.yml
@@ -11,6 +11,7 @@ on:
       ecr_registry:
         description: 'Name of ECR Registry to push images to'
         required: false
+        type: string
         default: 'public.ecr.aws/n8h5y2v5/rad-security'
 
 permissions:

--- a/.github/workflows/build-public-ecr-images.yml
+++ b/.github/workflows/build-public-ecr-images.yml
@@ -7,12 +7,11 @@ on:
         required: true
       AWS_GITHUB_RUNNER_SECRET_KEY:
         required: true
-
-inputs:
-  ecr_registry:
-    description: 'Name of ECR Registry to push images to'
-    required: false
-    default: 'public.ecr.aws/n8h5y2v5/rad-security'
+  inputs:
+    ecr_registry:
+      description: 'Name of ECR Registry to push images to'
+      required: false
+      default: 'public.ecr.aws/n8h5y2v5/rad-security'
 
 permissions:
   contents: write

--- a/.github/workflows/build-public-ecr-images.yml
+++ b/.github/workflows/build-public-ecr-images.yml
@@ -7,11 +7,11 @@ on:
         required: true
       AWS_GITHUB_RUNNER_SECRET_KEY:
         required: true
-  inputs:
-    ecr_registry:
-      description: 'Name of ECR Registry to push images to'
-      required: false
-      default: 'public.ecr.aws/n8h5y2v5/rad-security'
+    inputs:
+      ecr_registry:
+        description: 'Name of ECR Registry to push images to'
+        required: false
+        default: 'public.ecr.aws/n8h5y2v5/rad-security'
 
 permissions:
   contents: write

--- a/.github/workflows/build-public-ecr-images.yml
+++ b/.github/workflows/build-public-ecr-images.yml
@@ -1,0 +1,45 @@
+name: build-public-ecr-images
+
+on:
+  workflow_call:
+    secrets:
+      AWS_GITHUB_RUNNER_ACCESS_KEY:
+        required: true
+      AWS_GITHUB_RUNNER_SECRET_KEY:
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-public-images:
+    name: Build Public ECR Image
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'renovate') == false
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+          aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_GITHUB_RUNNER_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_GITHUB_RUNNER_SECRET_KEY }}
+
+    - name: Build ECR Image
+      run: make build_image
+      env:
+        GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        GITHUB_REF: ${{ github.ref }}
+        REGISTRY: public.ecr.aws/n8h5y2v5/rad-security
+        BRANCH: ${{ github.base_ref }}
+        COMMIT: ${{ github.sha }}

--- a/.github/workflows/build-public-ecr-images.yml
+++ b/.github/workflows/build-public-ecr-images.yml
@@ -31,9 +31,10 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v2
       with:
         registry-type: public
-        aws-region: us-east-1
-        aws-access-key-id: ${{ secrets.AWS_GITHUB_RUNNER_ACCESS_KEY }}
-        aws-secret-access-key: ${{ secrets.AWS_GITHUB_RUNNER_SECRET_KEY }}
+      env:
+        AWS_REGION: us-east-1
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GITHUB_RUNNER_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GITHUB_RUNNER_SECRET_KEY }}
 
     - name: Build ECR Image
       run: make build_image

--- a/.github/workflows/build-public-ecr-images.yml
+++ b/.github/workflows/build-public-ecr-images.yml
@@ -27,13 +27,13 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to Amazon ECR Public
-        id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registry-type: public
-          aws-region: us-east-1
-          aws-access-key-id: ${{ secrets.AWS_GITHUB_RUNNER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_GITHUB_RUNNER_SECRET_KEY }}
+      id: login-ecr-public
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        registry-type: public
+        aws-region: us-east-1
+        aws-access-key-id: ${{ secrets.AWS_GITHUB_RUNNER_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_GITHUB_RUNNER_SECRET_KEY }}
 
     - name: Build ECR Image
       run: make build_image

--- a/.github/workflows/build-public-ecr-images.yml
+++ b/.github/workflows/build-public-ecr-images.yml
@@ -7,6 +7,12 @@ on:
         required: true
       AWS_GITHUB_RUNNER_SECRET_KEY:
         required: true
+  inputs:
+    ecr_registry:
+      description: 'Name of ECR Registry to push images to'
+      required: false
+      default: 'public.ecr.aws/n8h5y2v5/rad-security'
+
 
 permissions:
   contents: write
@@ -41,6 +47,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         GITHUB_REF: ${{ github.ref }}
-        REGISTRY: public.ecr.aws/n8h5y2v5/rad-security
+        REGISTRY: ${{ inputs.ecr_registry }}
         BRANCH: ${{ github.base_ref }}
         COMMIT: ${{ github.sha }}

--- a/.github/workflows/build-public-ecr-images.yml
+++ b/.github/workflows/build-public-ecr-images.yml
@@ -7,12 +7,12 @@ on:
         required: true
       AWS_GITHUB_RUNNER_SECRET_KEY:
         required: true
-  inputs:
-    ecr_registry:
-      description: 'Name of ECR Registry to push images to'
-      required: false
-      default: 'public.ecr.aws/n8h5y2v5/rad-security'
 
+inputs:
+  ecr_registry:
+    description: 'Name of ECR Registry to push images to'
+    required: false
+    default: 'public.ecr.aws/n8h5y2v5/rad-security'
 
 permissions:
   contents: write


### PR DESCRIPTION
Towards ENG-2112

Adds ECR Public Image Github Action

The Github Action will be called like this:

```yaml
name: build-public-ecr-images

on:
  push:
    tags:
      - "v*"
  pull_request:

permissions:
  contents: write

jobs:
  build_public_ecr_images:
    uses: ksoc-private/go-github-actions/.github/workflows/build-public-ecr-images.yml@9edadf8efee6432d7632a28a5b5e6579c91ca208
    secrets: inherit
```

An example of it running can be found here: https://github.com/ksoc-private/plugin-ksoc-sync/actions/runs/11263632082/job/31321945261