### PR TITLE
Add Release step in build-public-ecr-images workflow

### DIFF
--- a/.github/workflows/build-public-ecr-images.yml
+++ b/.github/workflows/build-public-ecr-images.yml
@@ -52,3 +52,9 @@ jobs:
         REGISTRY: ${{ inputs.ecr_registry }}
         BRANCH: ${{ github.base_ref }}
         COMMIT: ${{ github.sha }}
+      
+    - name: "Create release"
+      if: startsWith(github.ref , 'refs/tags/v') == true
+      uses: "ergebnis/.github/actions/github/release/create@1.9.0"
+      with:
+        github-token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"


### PR DESCRIPTION
Currently all plugins don't have proper release in GH