### PR TITLE
Adds new goreleaser Github Action for Github Releases

### DIFF
--- a/.github/workflows/goreleaser_release.yml
+++ b/.github/workflows/goreleaser_release.yml
@@ -1,0 +1,56 @@
+name: Create Github Release
+
+on:
+  workflow_call:
+    secrets:
+      PERSONAL_ACCESS_TOKEN:
+        required: true
+
+permissions:
+   contents: write # needed to write releases
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          check-latest: true # https://github.com/actions/setup-go#check-latest-version
+          cache: true # https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
+        env:
+          GOPRIVATE: "github.com/ksoc-private"
+
+      - name: Configure git for private modules
+        env:
+          TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: git config --global url."https://ksocautomator:${TOKEN}@github.com".insteadOf "https://github.com"
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          install-only: true
+
+      - name: Release
+        if: startsWith(github.ref , 'refs/tags/v') == true
+        run: make release
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+      # Ref: https://github.com/convictional/trigger-workflow-and-wait
+      - name: Update api-client-ts
+        if: startsWith(github.ref , 'refs/tags/v') == true
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: ksoc-private
+          repo: api-client-ts
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          workflow_file_name: draft-release.yml
+          wait_workflow: false


### PR DESCRIPTION
Towards ENG-2294

Adds a new Github Action to create Github Releases. Ko does not have functionality for creating Github Releases. For Go services, Goreleaser is the easiest option. The other options for creating Github Releases require a lot more customization that we do not need.
