### PR TITLE
ENG-2544: Add Monorepo Support to Lint and Test

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,6 +16,11 @@ on:
         default: '5m'
         required: false
         type: string
+      workingdir:
+        description: 'working directory, used for monorepos. Default is .'
+        default: '.'
+        required: false
+        type: string
 
 permissions:
   # Required: allow read access to the content for analysis.
@@ -48,4 +53,5 @@ jobs:
         uses: golangci/golangci-lint-action@v5
         with:
           version: v1.64
+          working-directory: ${{ inputs.workingdir }}
           args: --timeout=${{ inputs.timeout }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,18 @@ on:
         default: 'go.sum'
         required: false
         type: string
+      workingdir:
+        description: 'working directory, used for monorepos. Default is .'
+        default: '.'
+        required: false
+        type: string
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.workingdir }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
This change updates the Go test and lint workflows to support a monorepo but allowing the specification of a working directory, in the case that the workflows need to be run against subdirectories in a repo.