### PR TITLE
Bump golangci linter

### DIFF
--- a/.github/workflows/golangci-lint-v2.yml
+++ b/.github/workflows/golangci-lint-v2.yml
@@ -52,6 +52,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.4
+          version: v2.9
           working-directory: ${{ inputs.workingdir }}
           args: --timeout=${{ inputs.timeout }}


### PR DESCRIPTION
Towards: https://linear.app/rad-security/issue/RAD-486/fix-critical-vulnerabilities-in-rad-plugins