### PR TITLE
Bump Go version to 1.27

### DIFF
--- a/.github/workflows/build-mod.yml
+++ b/.github/workflows/build-mod.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true # https://github.com/actions/setup-go#check-latest-version
           cache: true # https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
         env:

--- a/.github/workflows/golangci-lint-v2.yml
+++ b/.github/workflows/golangci-lint-v2.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true # https://github.com/actions/setup-go#check-latest-version
           cache: true # https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
           cache-dependency-path: ${{ inputs.cache-sum-files }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true # https://github.com/actions/setup-go#check-latest-version
           cache: true # https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
           cache-dependency-path: ${{ inputs.cache-sum-files }}

--- a/.github/workflows/goreleaser_release.yml
+++ b/.github/workflows/goreleaser_release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true # https://github.com/actions/setup-go#check-latest-version
           cache: true # https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
           cache-dependency-path: ${{ inputs.cache-sum-files }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true # https://github.com/actions/setup-go#check-latest-version
           cache: true # https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
           cache-dependency-path: ${{ inputs.cache-sum-files }}

--- a/.github/workflows/scan-codeql.yml
+++ b/.github/workflows/scan-codeql.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true # https://github.com/actions/setup-go#check-latest-version
           cache: true # https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
         env:

--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true # https://github.com/actions/setup-go#check-latest-version
           cache: true # https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true # https://github.com/actions/setup-go#check-latest-version
           cache: true # https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
           cache-dependency-path: ${{ inputs.cache-sum-files }}

--- a/marketplace-ecr-auth/action.yml
+++ b/marketplace-ecr-auth/action.yml
@@ -32,7 +32,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.26'
+        go-version: '1.27'
         check-latest: true
         cache: true
       env:

--- a/private-ecr-auth/action.yml
+++ b/private-ecr-auth/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.26'
+        go-version: '1.27'
         check-latest: true
         cache: true
       env:

--- a/public-ecr-auth/action.yaml
+++ b/public-ecr-auth/action.yaml
@@ -23,7 +23,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.26'
+        go-version: '1.27'
         check-latest: true
         cache: true
       env:


### PR DESCRIPTION
## Summary

- Bump `go-version` pin from `1.26` to `1.27` in 8 reusable workflows: `build-mod`, `test`, `release`, `goreleaser_release`, `swagger`, `scan-codeql`, `golangci-lint`, `golangci-lint-v2`
- Bump `go-version` pin from `1.26` to `1.27` in 3 composite actions: `marketplace-ecr-auth`, `private-ecr-auth`, `public-ecr-auth`
- No `go.mod` in this repo (actions-only), so no module directive to update

🤖 Generated with [Claude Code](https://claude.com/claude-code)