### PR TITLE
fix(ci): bump golangci-lint to v2.13.1 for go1.27 support

### DIFF
--- a/.github/workflows/golangci-lint-v2.yml
+++ b/.github/workflows/golangci-lint-v2.yml
@@ -52,6 +52,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.9
+          version: v2.13.1
           working-directory: ${{ inputs.workingdir }}
           args: --timeout=${{ inputs.timeout }}


### PR DESCRIPTION
## Problem

The reusable `golangci-lint-v2` workflow installs Go 1.27 (`setup-go` `go-version: '1.27'`) but pins golangci-lint **v2.9**, a binary built with go1.26. Since the GitHub runner image began shipping Go 1.27 (~2026-08-23), golangci-lint panics type-checking go1.27 stdlib:

```
panic: file requires newer Go version go1.27 (application built with go1.26)
##[error]golangci-lint exit with code 2
```

This fails the `lint` check on **every** repo/PR that consumes this reusable workflow. It's a time boundary, not a code boundary — lint was green on all branches through 2026-08-24 and red on the first PR to run since (e.g. `ksoc-private/runtimer#592`, where build + test + goreleaser are all green and only lint panics).

## Fix

Bump golangci-lint `v2.9` → `v2.13.1`. golangci-lint v2.13.0 added go1.27 support (golangci/golangci-lint#6642). No `go-version` change; same v2 major line.

## After merge

Re-run `lint` on dependent open PRs (e.g. runtimer#592) — no downstream change needed since they reference `...golangci-lint-v2.yml@main`.